### PR TITLE
fix: Correction du débordement des descriptions dans les cartes de projet

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,14 @@
 @import "tailwindcss";
 
+/* Classe personnalisée pour limiter le texte à 3 lignes */
+.line-clamp-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 :root {
   /* Thème sombre */
   --background: #0a0a0a;

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -47,7 +47,12 @@ export default function ProjectCard({ project }: ProjectCardProps) {
         </div>
       </div>
 
-      <p className="text-muted-foreground mb-4 leading-relaxed">
+      <p className="text-muted-foreground mb-4 leading-relaxed overflow-hidden max-h-[4.5rem] text-ellipsis" 
+         style={{
+           display: '-webkit-box',
+           WebkitLineClamp: 3,
+           WebkitBoxOrient: 'vertical'
+         }}>
         {project.description}
       </p>
 


### PR DESCRIPTION
- Limitation de la description à 3 lignes maximum dans ProjectCard
- Ajout de la classe CSS line-clamp-3 personnalisée
- Utilisation de overflow hidden et WebKit box properties
- Améliorer l'affichage des descriptions longues
- Maintenir la cohérence visuelle de la grille de projets

Corrige le problème de débordement de texte qui cassait la mise en page.