### PR TITLE
Feature/minor UI fix  

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -16,7 +16,7 @@ export default function Navbar() {
             alt="Drapeau du Togo"
             width={24}
             height={24}
-            className="h-6 mr-2"
+            className=" object-contain w-7 mr-2"
           />
           <h1 className="text-xl font-bold text-foreground">OS228</h1>
         </div>

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -21,11 +21,11 @@ export default function ProjectCard({ project }: ProjectCardProps) {
 
   return (
     <div className="bg-card rounded-lg p-6 shadow-lg hover:shadow-xl transition-shadow duration-300 border border-border">
-      <div className="flex items-center  justify-between  mb-4">
-        <h3 className="text-xl font-bold line-clamp-1 text-card-foreground">
+      <div className="flex items-start  justify-between  mb-4">
+        <h3 className="text-xl font-bold leading-6 text-card-foreground">
           {project.name}
         </h3>
-        <div className="flex  align-middle gap-3 text-muted-foreground text-sm">
+        <div className="flex h-6 bg-red-500 items-center gap-3 text-muted-foreground text-sm">
           {loading ? (
             <div className="flex items-center gap-2">
               <div className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -25,7 +25,7 @@ export default function ProjectCard({ project }: ProjectCardProps) {
         <h3 className="text-xl font-bold leading-6 text-card-foreground">
           {project.name}
         </h3>
-        <div className="flex h-6 bg-red-500 items-center gap-3 text-muted-foreground text-sm">
+        <div className="flex h-6  items-center gap-3 text-muted-foreground text-sm">
           {loading ? (
             <div className="flex items-center gap-2">
               <div className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -21,11 +21,11 @@ export default function ProjectCard({ project }: ProjectCardProps) {
 
   return (
     <div className="bg-card rounded-lg p-6 shadow-lg hover:shadow-xl transition-shadow duration-300 border border-border">
-      <div className="flex justify-between items-start mb-4">
-        <h3 className="text-xl font-bold text-card-foreground mb-2">
+      <div className="flex items-center  justify-between  mb-4">
+        <h3 className="text-xl font-bold line-clamp-1 text-card-foreground">
           {project.name}
         </h3>
-        <div className="flex items-center gap-3 text-muted-foreground text-sm">
+        <div className="flex  align-middle gap-3 text-muted-foreground text-sm">
           {loading ? (
             <div className="flex items-center gap-2">
               <div className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>
@@ -37,7 +37,7 @@ export default function ProjectCard({ project }: ProjectCardProps) {
                 <span>⭐</span>
                 <span className="font-medium">{stats.stars}</span>
               </div>
-              <div className="flex items-center gap-1">
+              <div className="flex  items-center gap-1">
                 {/* Icône fork GitHub (revu) */}
                 <svg
                   className="w-4 h-4"
@@ -51,7 +51,7 @@ export default function ProjectCard({ project }: ProjectCardProps) {
               </div>
             </>
           ) : (
-            <div className="flex items-center gap-1 text-muted-foreground">
+            <div className="flex  items-center gap-1 text-muted-foreground">
               <span className="text-xs">Stats non disponibles</span>
             </div>
           )}


### PR DESCRIPTION
- [x] Fix stretching issue on the 228 icon logo  

- [x] Align project cards and their icons visually
<img width="148" height="47" alt="CleanShot 2025-10-01 at 13 32 56" src="https://github.com/user-attachments/assets/6081e973-239a-4261-b7ab-c6513e3d8a37" />
<img width="1132" height="217" alt="CleanShot 2025-10-01 at 13 34 34" src="https://github.com/user-attachments/assets/8e73da13-e44b-4f1e-8ab2-701b95db3563" />
